### PR TITLE
Bug fixed - Changing the font or year triggered a new quiz question/reloaded page

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,6 @@
 <body>
   <div id="quiz-container">
     <div id="header-controls">
-      <label for="year-filter">Year:</label>
       <select id="year-filter">
         <option value="all" class="all-years">All Years</option>
         <option value="1">一上 (100)</option>
@@ -230,7 +229,6 @@
         <option value="26">六上 (112)</option>
         <option value="27">六下 (80)</option>
       </select>
-      <label for="font-filter">Font:</label>
       <select id="font-filter">
         <option value="Noto Sans SC">Noto Sans SC</option>
         <option value="Ma Shan Zheng">Ma Shan Zheng</option>
@@ -242,7 +240,7 @@
       <h2 id="pinyin-question">Pinyin will appear here</h2>
       <div id="grid"></div>
       <p id="feedback"></p>
-      <button id="next-question">Next Question</button>
+      <button id="next-quiz" type="button" onclick="loadNewCharacter()">Next Question</button>
     </div>
   </div>
   <script>
@@ -375,48 +373,33 @@
       document.querySelectorAll("#grid button").forEach(btn => btn.disabled = true);
     }
 
-    document.getElementById("next-quiz").addEventListener("click", generateQuiz);
-    document.getElementById("year-filter").addEventListener("change", () => {
-      resetScore();
-      generateQuiz();
+document.getElementById("year-filter").addEventListener("change", updateYear);
+document.getElementById("font-filter").addEventListener("change", updateFont);
+document.addEventListener("DOMContentLoaded", function () {
+  document.getElementById("next-quiz").addEventListener("click", generateQuiz);
+});
+
+function updateFont() {
+    const selectedFont = document.getElementById("font-filter").value;
+    const fontToApply = selectedFont || "Noto Sans SC";
+    document.querySelectorAll("#grid button").forEach(button => {
+      button.style.fontFamily = `'${fontToApply}', sans-serif`;
+      button.classList.remove("font-noto-sans-sc", "font-ma-shan-zheng", "font-long-cang");
+      if (fontToApply === "Noto Sans SC") {
+        button.classList.add("font-noto-sans-sc");
+      } else if (fontToApply === "Ma Shan Zheng") {
+        button.classList.add("font-ma-shan-zheng");
+      } else if (fontToApply === "Long Cang") {
+        button.classList.add("font-long-cang");
+      }
     });
-    document.getElementById("font-filter").addEventListener("change", () => {
-      updateFont();
-      generateQuiz();
-    });
-    
-    document.getElementById("font-filter").addEventListener("change", updateFont);
-    document.getElementById("year-filter").addEventListener("change", updateYear);
+  }
 
-    function updateFont() {
-      const selectedFont = document.getElementById("font-filter").value;
-      const fontToApply = selectedFont || "Noto Sans SC";
-
-      document.querySelectorAll("#grid button").forEach(button => {
-        button.style.fontFamily = `'${fontToApply}', sans-serif`;
-        button.classList.remove("font-noto-sans-sc", "font-ma-shan-zheng", "font-long-cang");
-
-        if (fontToApply === "Noto Sans SC") {
-          button.classList.add("font-noto-sans-sc");
-        } else if (fontToApply === "Ma Shan Zheng") {
-          button.classList.add("font-ma-shan-zheng");
-        } else if (fontToApply === "Long Cang") {
-          button.classList.add("font-long-cang");
-        }
-      });
-    }
-
-    function updateYear() {
-      const selectedYear = document.getElementById("year-filter").value;
-      // Just update filter setting here, do not trigger question unless explicitly desired
-      console.log("Year changed to:", selectedYear);
-      // Optionally refresh available characters if needed
-    }
-
-    document.getElementById("next-question").addEventListener("click", function () {
-      // Your existing logic to show next question
-      console.log("Next question triggered");
-    });
+  function updateYear() {
+    const selectedYear = document.getElementById("year-filter").value;
+    // Set global filter if needed, but do not call loadNewCharacter()
+    console.log("Year changed to:", selectedYear);
+  }
   
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
 <body>
   <div id="quiz-container">
     <div id="header-controls">
+      <label for="year-filter">Year:</label>
       <select id="year-filter">
         <option value="all" class="all-years">All Years</option>
         <option value="1">一上 (100)</option>
@@ -229,8 +230,8 @@
         <option value="26">六上 (112)</option>
         <option value="27">六下 (80)</option>
       </select>
+      <label for="font-filter">Font:</label>
       <select id="font-filter">
-        <option value="" disabled selected class="font-placeholder">Font</option>
         <option value="Noto Sans SC">Noto Sans SC</option>
         <option value="Ma Shan Zheng">Ma Shan Zheng</option>
         <option value="Long Cang">Long Cang</option>
@@ -241,7 +242,7 @@
       <h2 id="pinyin-question">Pinyin will appear here</h2>
       <div id="grid"></div>
       <p id="feedback"></p>
-      <button id="next-quiz">Next Question</button>
+      <button id="next-question">Next Question</button>
     </div>
   </div>
   <script>
@@ -369,7 +370,7 @@
       }
 
       document.querySelectorAll("#grid button .text-container").forEach(div => {
-        div.style.display = "flex"; /* Use flex to maintain layout */
+        div.style.display = "flex";
       });
       document.querySelectorAll("#grid button").forEach(btn => btn.disabled = true);
     }
@@ -383,6 +384,40 @@
       updateFont();
       generateQuiz();
     });
+    
+    document.getElementById("font-filter").addEventListener("change", updateFont);
+    document.getElementById("year-filter").addEventListener("change", updateYear);
+
+    function updateFont() {
+      const selectedFont = document.getElementById("font-filter").value;
+      const fontToApply = selectedFont || "Noto Sans SC";
+
+      document.querySelectorAll("#grid button").forEach(button => {
+        button.style.fontFamily = `'${fontToApply}', sans-serif`;
+        button.classList.remove("font-noto-sans-sc", "font-ma-shan-zheng", "font-long-cang");
+
+        if (fontToApply === "Noto Sans SC") {
+          button.classList.add("font-noto-sans-sc");
+        } else if (fontToApply === "Ma Shan Zheng") {
+          button.classList.add("font-ma-shan-zheng");
+        } else if (fontToApply === "Long Cang") {
+          button.classList.add("font-long-cang");
+        }
+      });
+    }
+
+    function updateYear() {
+      const selectedYear = document.getElementById("year-filter").value;
+      // Just update filter setting here, do not trigger question unless explicitly desired
+      console.log("Year changed to:", selectedYear);
+      // Optionally refresh available characters if needed
+    }
+
+    document.getElementById("next-question").addEventListener("click", function () {
+      // Your existing logic to show next question
+      console.log("Next question triggered");
+    });
+  
   </script>
 </body>
 </html>


### PR DESCRIPTION
Removed unnecessary `generateQuiz()` calls in the font and year event listeners to ensure only appearance updates. Updated the `next-quiz` button listener to trigger `generateQuiz()` without interference from font/year changes. Ensured that the font and year changes no longer reset or reload the quiz state unintentionally.